### PR TITLE
Add reset to store, optional original instance

### DIFF
--- a/src/Exim.js
+++ b/src/Exim.js
@@ -10,38 +10,40 @@ Exim.cx = function (classNames) {
   }
 };
 
-var domHelpers = {};
+if (typeof React !== 'undefined') {
+  var domHelpers = {};
 
-var tag = function (name) {
-  var args, attributes, name;
-  args = [].slice.call(arguments, 1);
-  var first = args[0] && args[0].constructor;
-  if (first === Object) {
-    attributes = args.shift();
-  } else {
-    attributes = {};
-  }
-  return React.DOM[name].apply(React.DOM, [attributes].concat(args))
-};
-
-var bindTag = function(tagName) {
-  return domHelpers[tagName] = tag.bind(this, tagName);
-};
-
-for (var tagName in React.DOM) {
-  bindTag(tagName);
-}
-
-domHelpers['space'] = function() {
-  return React.DOM.span({
-    dangerouslySetInnerHTML: {
-      __html: '&nbsp;'
+  var tag = function (name) {
+    var args, attributes, name;
+    args = [].slice.call(arguments, 1);
+    var first = args[0] && args[0].constructor;
+    if (first === Object) {
+      attributes = args.shift();
+    } else {
+      attributes = {};
     }
-  });
-};
+    return React.DOM[name].apply(React.DOM, [attributes].concat(args))
+  };
 
-Exim.DOM = domHelpers;
+  var bindTag = function(tagName) {
+    return domHelpers[tagName] = tag.bind(this, tagName);
+  };
 
-Exim.addTag = function (name, tag) {
-  this.DOM[name] = tag;
+  for (var tagName in React.DOM) {
+    bindTag(tagName);
+  }
+
+  domHelpers['space'] = function() {
+    return React.DOM.span({
+      dangerouslySetInnerHTML: {
+        __html: '&nbsp;'
+      }
+    });
+  };
+
+  Exim.DOM = domHelpers;
+
+  Exim.addTag = function (name, tag) {
+    this.DOM[name] = tag;
+  }
 }

--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -66,12 +66,8 @@ Reflux.ListenerMethods = {
      * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is the object being listened to
      */
     listenTo: function(listenable, callback, defaultCallback) {
-        if (!Promise) {
-            Promise = {
-                is: function () {
-                    return false;
-                }
-            }
+        var isPromise = function (target) {
+            return typeof Promise !== 'undefined' && typeof target !== 'undefined' && target.constructor === Promise;
         }
 
         var desub, unsubscriber, catchError, cb, subscriptionobj,
@@ -97,7 +93,7 @@ Reflux.ListenerMethods = {
                     console.error(e);
                     return errorFn ? errorFn.call(this, e) : null;
                 }
-                isPrevPromise = Promise.is(prevResult);
+                isPrevPromise = isPromise(prevResult);
             }
 
             if (whileFn) {
@@ -107,7 +103,7 @@ Reflux.ListenerMethods = {
             var fn = utils.lookupCallback(this, callback);
             var fnArguments = prevResult && !isPrevPromise ? [prevResult] : arguments;
             var fnResult = prevFn && isPrevPromise ? prevResult.then(fn.bind(this)) :  fn.apply(this, fnArguments);
-            var isPromise = Promise.is(fnResult);
+            var isCurrentPromise = isPromise(fnResult);
             var self = this;
 
             var nextCb = function (fn) {
@@ -120,7 +116,7 @@ Reflux.ListenerMethods = {
             };
 
             if (nextFn) {
-                if (isPromise) {
+                if (isCurrentPromise) {
                     fnResult.then(nextCb(nextFn), nextCb(errorFn));
                 } else {
                     nextCb(nextFn).call(this, fnResult);

--- a/src/connect.js
+++ b/src/connect.js
@@ -56,24 +56,3 @@ Reflux.connect = function (listenable, key) {
     componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount
   };
 };
-
-Reflux.onChange = function (listenable, cb) {
-  for(var m in Reflux.ListenerMethods) {
-    if (this[m] !== Reflux.ListenerMethods[m]){
-      if (this[m]) {
-        throw "Can't have other property '"+m+"' when using Reflux.listenTo!";
-      }
-      this[m] = Reflux.ListenerMethods[m];
-    }
-  }
-
-  callback = function () {
-    cb(listenable.get());
-  }
-
-  listenable.listen(callback)
-};
-
-// Reflux.watch = function (listenable, keys) {
-
-// };

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,7 +1,3 @@
-// var Reflux = require('../src'),
-//     _ = require('./utils');
-
-
 Reflux.connect = function (listenable, key) {
   var key = arguments.length > 2 ? [].slice.call(arguments, 1) : key;
 
@@ -59,6 +55,23 @@ Reflux.connect = function (listenable, key) {
     },
     componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount
   };
+};
+
+Reflux.onChange = function (listenable, cb) {
+  for(var m in Reflux.ListenerMethods) {
+    if (this[m] !== Reflux.ListenerMethods[m]){
+      if (this[m]) {
+        throw "Can't have other property '"+m+"' when using Reflux.listenTo!";
+      }
+      this[m] = Reflux.ListenerMethods[m];
+    }
+  }
+
+  callback = function () {
+    cb(listenable.get());
+  }
+
+  listenable.listen(callback)
 };
 
 // Reflux.watch = function (listenable, keys) {

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -87,6 +87,8 @@ Reflux.createStore = function(definition) {
         return utils.clone(result);
     };
 
+    utils.inheritMixins(Store, definition.mixins);
+
     utils.extend(Store.prototype, Reflux.ListenerMethods, Reflux.PublisherMethods, definition);
 
     var store = new Store();

--- a/src/footer.js
+++ b/src/footer.js
@@ -45,7 +45,6 @@
   Exim.createAction = Reflux.createAction;
   Exim.createActions = Reflux.createActions;
   Exim.createStore = Reflux.createStore;
-  Exim.createView = React.createClass;
 
   return Exim;
 });

--- a/src/header.js
+++ b/src/header.js
@@ -13,8 +13,4 @@
 })(this, function(root, Reflux) {
   "use strict";
 
-  if (typeof React === 'undefined') {
-    throw("React required");
-  }
-
   var Reflux = {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,14 @@ utils.extend = function(obj) {
     return obj;
 };
 
+utils.inheritMixins = function (target, mixins) {
+    if (mixins) {
+        mixins.forEach(function (mixin) {
+            utils.extend(target.prototype, mixin);
+        })
+    }
+};
+
 utils.EventEmitter = EventEmitter;
 
 utils.isFunction = function(value) {


### PR DESCRIPTION
1) `get` optionally returns original instance:
``` javascript

storeMethod: function () {
  var object  = {foo: 'bar'};
  this.update('data', object);
  object === this.get('data'); //false
  object === this.get('data', true); //true
};

```

2) `reset` - set store to `getInitial`s result or empty object.

``` javascript
getInitial: function () {
  return {foo: 'bar'}
},
storeMethod: function () {
  this.update('foo', 'baz')
  this.update('quux', 'quuux')
  this.get('foo') // 'baz'
  this.reset()
  this.get('foo') // 'bar'
  this.get('quux') // undefined
};

```
