### PR TITLE
0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Optional dependency: **Bluebird** - ultra-fast promises
 
 ## Changelog
 
+### Exim 0.5.0 (6 May 2015)
+
+1. Implement **Exim.createView**.
+2. **Exim.Router** enhancements.
+3. Add **Exim.helpers**.
+
 ### Exim 0.4.0 (9 Dec 2014)
 
 Initial release.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "exim",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "authors": [
     "Paul Miller <paul@paulmillr.com>",
     "Artem Yavorsky <artem@yavorsky.org>"
@@ -8,8 +8,8 @@
   "description": "An architecture for HTML5 apps using Facebook's Flux.js library.",
   "main": "exim.js",
   "dependencies": {
-    "react": "~0.12.1",
-    "react-router": "~0.11.4"
+    "react": "~0.13.2",
+    "react-router": "0.13.3"
   },
   "devDependencies": {
     "qunit": "~1"

--- a/exim.js
+++ b/exim.js
@@ -16,9 +16,7 @@
   var React = require('react');
   var ReactRouter = require('react-router');
 
-  if (typeof React === 'undefined') {
-    throw("React required");
-  }
+  var Reflux = {};
 /*!
  * EventEmitter v4.2.9 - git.io/ee
  * Oliver Caldwell
@@ -753,12 +751,8 @@ Reflux.ListenerMethods = {
      * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is the object being listened to
      */
     listenTo: function(listenable, callback, defaultCallback) {
-        if (!Promise) {
-            Promise = {
-                is: function () {
-                    return false;
-                }
-            }
+        var isPromise = function (target) {
+            return typeof Promise !== 'undefined' && typeof target !== 'undefined' && target.constructor === Promise;
         }
 
         var desub, unsubscriber, catchError, cb, subscriptionobj,
@@ -784,7 +778,7 @@ Reflux.ListenerMethods = {
                     console.error(e);
                     return errorFn ? errorFn.call(this, e) : null;
                 }
-                isPrevPromise = Promise.is(prevResult);
+                isPrevPromise = isPromise(prevResult);
             }
 
             if (whileFn) {
@@ -794,7 +788,7 @@ Reflux.ListenerMethods = {
             var fn = utils.lookupCallback(this, callback);
             var fnArguments = prevResult && !isPrevPromise ? [prevResult] : arguments;
             var fnResult = prevFn && isPrevPromise ? prevResult.then(fn.bind(this)) :  fn.apply(this, fnArguments);
-            var isPromise = Promise.is(fnResult);
+            var isCurrentPromise = isPromise(fnResult);
             var self = this;
 
             var nextCb = function (fn) {
@@ -807,7 +801,7 @@ Reflux.ListenerMethods = {
             };
 
             if (nextFn) {
-                if (isPromise) {
+                if (isCurrentPromise) {
                     fnResult.then(nextCb(nextFn), nextCb(errorFn));
                 } else {
                     nextCb(nextFn).call(this, fnResult);
@@ -1112,6 +1106,8 @@ Reflux.createStore = function(definition) {
         return utils.clone(result);
     };
 
+    utils.inheritMixins(Store, definition.mixins);
+
     utils.extend(Store.prototype, Reflux.ListenerMethods, Reflux.PublisherMethods, definition);
 
     var store = new Store();
@@ -1142,10 +1138,6 @@ Keep.reset = function() {
         createdActions.pop();
     }
 };
-// var Reflux = require('../src'),
-//     _ = require('./utils');
-
-
 Reflux.connect = function (listenable, key) {
   var key = arguments.length > 2 ? [].slice.call(arguments, 1) : key;
 
@@ -1204,10 +1196,6 @@ Reflux.connect = function (listenable, key) {
     componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount
   };
 };
-
-// Reflux.watch = function (listenable, keys) {
-
-// };
 // var _ = require('./utils'),
 //     ListenerMethods = require('./ListenerMethods');
 
@@ -1344,6 +1332,7 @@ Reflux.__keep = Keep;
 var Exim = Reflux;
 
 Exim.cx = function (classNames) {
+  console.log('`Exim.cx` is deprecated and will be removed in next versions. Use `Exim.helpers.cx` instead');
   if (typeof classNames == 'object') {
     return Object.keys(classNames).filter(function(className) {
       return classNames[className];
@@ -1353,45 +1342,69 @@ Exim.cx = function (classNames) {
   }
 };
 
-var domHelpers = {};
+var helpers = {};
 
-var tag = function (name) {
-  var args, attributes, name;
-  args = [].slice.call(arguments, 1);
-  var first = args[0] && args[0].constructor;
-  if (first === Object) {
-    attributes = args.shift();
+helpers.cx = function (classNames) {
+  if (typeof classNames == 'object') {
+    return Object.keys(classNames).filter(function(className) {
+      return classNames[className];
+    }).join(' ');
   } else {
-    attributes = {};
+    return Array.prototype.join.call(arguments, ' ');
   }
-  return React.DOM[name].apply(React.DOM, [attributes].concat(args))
 };
 
-var bindTag = function(tagName) {
-  return domHelpers[tagName] = tag.bind(this, tagName);
-};
+Exim.helpers = helpers;
 
-for (var tagName in React.DOM) {
-  bindTag(tagName);
-}
+if (typeof React !== 'undefined') {
+  var domHelpers = {};
 
-domHelpers['space'] = function() {
-  return React.DOM.span({
-    dangerouslySetInnerHTML: {
-      __html: '&nbsp;'
+  var tag = function (name) {
+    var args, attributes, name;
+    args = [].slice.call(arguments, 1);
+    var first = args[0] && args[0].constructor;
+    if (first === Object) {
+      attributes = args.shift();
+    } else {
+      attributes = {};
     }
-  });
-};
+    return React.DOM[name].apply(React.DOM, [attributes].concat(args))
+  };
 
-Exim.DOM = domHelpers;
+  var bindTag = function(tagName) {
+    return domHelpers[tagName] = tag.bind(this, tagName);
+  };
 
-Exim.addTag = function (name, tag) {
-  this.DOM[name] = tag;
+  for (var tagName in React.DOM) {
+    bindTag(tagName);
+  }
+
+  domHelpers['space'] = function() {
+    return React.DOM.span({
+      dangerouslySetInnerHTML: {
+        __html: '&nbsp;'
+      }
+    });
+  };
+
+  Exim.DOM = domHelpers;
+
+  Exim.addTag = function (name, tag) {
+    this.DOM[name] = tag;
+  }
 }
 
   var toS = Object.prototype.toString;
 
   if (typeof ReactRouter === "object") {
+    var routerElements, routerMixins, routerFunctions, routerObjects, copyItems;
+
+    routerElements = ['Route', 'DefaultRoute', 'RouteHandler', 'ActiveHandler', 'NotFoundRoute', 'Link', 'Redirect'];
+    routerMixins = ['Navigation', 'State'];
+    routerFunctions = ['create', 'createDefaultRoute', 'createNotFoundRoute', 'createRedirect', 'createRoute', 'createRoutesFromReactChildren', 'run'];
+    routerObjects = ['HashLocation', 'History', 'HistoryLocation', 'RefreshLocation', 'StaticLocation', 'TestLocation', 'ImitateBrowserBehavior', 'ScrollToTopBehavior'];
+    copyItems = routerMixins.concat(routerFunctions).concat(routerObjects);
+
     Exim.Router = {
       match: function(name, View) {
         var options = {};
@@ -1426,16 +1439,26 @@ Exim.addTag = function (name, tag) {
       }
     };
 
+    for (var i = 0; i < routerElements.length; i++) {
+      var elementName = routerElements[i];
+      Exim.Router[elementName] = React.createElement.bind(React.createElement, ReactRouter[elementName]);
+    }
 
-    ['Link', 'transitionTo', 'goBack', 'replaceWith', 'Route', 'RouteHandler', 'State', 'Link'].forEach(function(name) {
-      Exim.Router[name] = ReactRouter[name]
-    });
+    for (var i = 0; i < copyItems.length; i++) {
+      var itemName = copyItems[i];
+      Exim.Router[itemName] = ReactRouter[itemName];
+    }
   }
+
+  Exim.createView = function (classArgs) {
+    var ReactClass = React.createClass(classArgs);
+    var ReactElement = React.createElement.bind(React.createElement, ReactClass);
+    return ReactElement;
+  };
 
   Exim.createAction = Reflux.createAction;
   Exim.createActions = Reflux.createActions;
   Exim.createStore = Reflux.createStore;
-  Exim.createView = React.createClass;
 
   return Exim;
 });

--- a/exim.js
+++ b/exim.js
@@ -13,10 +13,21 @@
   }
 })(this, function(root, Reflux) {
   "use strict";
-  var React = require('react');
-  var ReactRouter = require('react-router');
-
+  var React, ReactRouter;
   var Reflux = {};
+
+  if (typeof define === 'function' && define.amd) {
+    React = require('react');
+    ReactRouter = require('react-router');
+  }
+  else if (typeof module === 'object' && module.exports){
+    React = module.exports.React;
+    ReactRouter = module.exports.ReactRouter;
+  }
+  else {
+    React = window.React;
+    ReactRouter = window.ReactRouter;
+  }
 /*!
  * EventEmitter v4.2.9 - git.io/ee
  * Oliver Caldwell

--- a/exim.js
+++ b/exim.js
@@ -526,22 +526,30 @@ if (typeof define === 'function' && define.amd) {
   utils.EventEmitter = require('EventEmitter')
 }
 else if (typeof module === 'object' && module.exports){
-    utils.EventEmitter = module.exports.EventEmitter;
+  utils.EventEmitter = module.exports.EventEmitter;
 }
 else {
-    utils.EventEmitter = window.EventEmitter;
+  utils.EventEmitter = window.EventEmitter;
 }
 
 utils.isFunction = function(value) {
-    return typeof value === 'function';
+  return typeof value === 'function';
 };
 
 utils.nextTick = function(callback) {
-    setTimeout(callback, 0);
+  setTimeout(callback, 0);
 };
 
 utils.capitalize = function(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+utils.inheritMixins = function (target, mixins) {
+  if (mixins) {
+    mixins.forEach(function (mixin) {
+      utils.extend(target.prototype, mixin);
+    })
+  }
 };
 
 utils.lookupCallback = function(store, name, prefix) {
@@ -559,11 +567,11 @@ utils.lookupCallback = function(store, name, prefix) {
 };
 
 utils.object = function(keys,vals){
-    var o={}, i=0;
-    for(;i<keys.length;i++){
-        o[keys[i]] = vals[i];
-    }
-    return o;
+  var o={}, i=0;
+  for(;i<keys.length;i++){
+      o[keys[i]] = vals[i];
+  }
+  return o;
 };
 
 utils.clone = function (orig) {

--- a/src/Exim.js
+++ b/src/Exim.js
@@ -1,6 +1,7 @@
 var Exim = Reflux;
 
 Exim.cx = function (classNames) {
+  console.log('`Exim.cx` is deprecated and will be removed in next versions. Use `Exim.helpers.cx` instead');
   if (typeof classNames == 'object') {
     return Object.keys(classNames).filter(function(className) {
       return classNames[className];
@@ -10,38 +11,54 @@ Exim.cx = function (classNames) {
   }
 };
 
-var domHelpers = {};
+var helpers = {};
 
-var tag = function (name) {
-  var args, attributes, name;
-  args = [].slice.call(arguments, 1);
-  var first = args[0] && args[0].constructor;
-  if (first === Object) {
-    attributes = args.shift();
+helpers.cx = function (classNames) {
+  if (typeof classNames == 'object') {
+    return Object.keys(classNames).filter(function(className) {
+      return classNames[className];
+    }).join(' ');
   } else {
-    attributes = {};
+    return Array.prototype.join.call(arguments, ' ');
   }
-  return React.DOM[name].apply(React.DOM, [attributes].concat(args))
 };
 
-var bindTag = function(tagName) {
-  return domHelpers[tagName] = tag.bind(this, tagName);
-};
+Exim.helpers = helpers;
 
-for (var tagName in React.DOM) {
-  bindTag(tagName);
-}
+if (typeof React !== 'undefined') {
+  var domHelpers = {};
 
-domHelpers['space'] = function() {
-  return React.DOM.span({
-    dangerouslySetInnerHTML: {
-      __html: '&nbsp;'
+  var tag = function (name) {
+    var args, attributes, name;
+    args = [].slice.call(arguments, 1);
+    var first = args[0] && args[0].constructor;
+    if (first === Object) {
+      attributes = args.shift();
+    } else {
+      attributes = {};
     }
-  });
-};
+    return React.DOM[name].apply(React.DOM, [attributes].concat(args))
+  };
 
-Exim.DOM = domHelpers;
+  var bindTag = function(tagName) {
+    return domHelpers[tagName] = tag.bind(this, tagName);
+  };
 
-Exim.addTag = function (name, tag) {
-  this.DOM[name] = tag;
+  for (var tagName in React.DOM) {
+    bindTag(tagName);
+  }
+
+  domHelpers['space'] = function() {
+    return React.DOM.span({
+      dangerouslySetInnerHTML: {
+        __html: '&nbsp;'
+      }
+    });
+  };
+
+  Exim.DOM = domHelpers;
+
+  Exim.addTag = function (name, tag) {
+    this.DOM[name] = tag;
+  }
 }

--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -66,12 +66,8 @@ Reflux.ListenerMethods = {
      * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is the object being listened to
      */
     listenTo: function(listenable, callback, defaultCallback) {
-        if (!Promise) {
-            Promise = {
-                is: function () {
-                    return false;
-                }
-            }
+        var isPromise = function (target) {
+            return typeof Promise !== 'undefined' && typeof target !== 'undefined' && target.constructor === Promise;
         }
 
         var desub, unsubscriber, catchError, cb, subscriptionobj,
@@ -97,7 +93,7 @@ Reflux.ListenerMethods = {
                     console.error(e);
                     return errorFn ? errorFn.call(this, e) : null;
                 }
-                isPrevPromise = Promise.is(prevResult);
+                isPrevPromise = isPromise(prevResult);
             }
 
             if (whileFn) {
@@ -107,7 +103,7 @@ Reflux.ListenerMethods = {
             var fn = utils.lookupCallback(this, callback);
             var fnArguments = prevResult && !isPrevPromise ? [prevResult] : arguments;
             var fnResult = prevFn && isPrevPromise ? prevResult.then(fn.bind(this)) :  fn.apply(this, fnArguments);
-            var isPromise = Promise.is(fnResult);
+            var isCurrentPromise = isPromise(fnResult);
             var self = this;
 
             var nextCb = function (fn) {
@@ -120,7 +116,7 @@ Reflux.ListenerMethods = {
             };
 
             if (nextFn) {
-                if (isPromise) {
+                if (isCurrentPromise) {
                     fnResult.then(nextCb(nextFn), nextCb(errorFn));
                 } else {
                     nextCb(nextFn).call(this, fnResult);

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,7 +1,3 @@
-// var Reflux = require('../src'),
-//     _ = require('./utils');
-
-
 Reflux.connect = function (listenable, key) {
   var key = arguments.length > 2 ? [].slice.call(arguments, 1) : key;
 
@@ -60,7 +56,3 @@ Reflux.connect = function (listenable, key) {
     componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount
   };
 };
-
-// Reflux.watch = function (listenable, keys) {
-
-// };

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -87,6 +87,8 @@ Reflux.createStore = function(definition) {
         return utils.clone(result);
     };
 
+    utils.inheritMixins(Store, definition.mixins);
+
     utils.extend(Store.prototype, Reflux.ListenerMethods, Reflux.PublisherMethods, definition);
 
     var store = new Store();

--- a/src/footer.js
+++ b/src/footer.js
@@ -2,6 +2,14 @@
   var toS = Object.prototype.toString;
 
   if (typeof ReactRouter === "object") {
+    var routerElements, routerMixins, routerFunctions, routerObjects, copyItems;
+
+    routerElements = ['Route', 'DefaultRoute', 'RouteHandler', 'ActiveHandler', 'NotFoundRoute', 'Link', 'Redirect'];
+    routerMixins = ['Navigation', 'State'];
+    routerFunctions = ['create', 'createDefaultRoute', 'createNotFoundRoute', 'createRedirect', 'createRoute', 'createRoutesFromReactChildren', 'run'];
+    routerObjects = ['HashLocation', 'History', 'HistoryLocation', 'RefreshLocation', 'StaticLocation', 'TestLocation', 'ImitateBrowserBehavior', 'ScrollToTopBehavior'];
+    copyItems = routerMixins.concat(routerFunctions).concat(routerObjects);
+
     Exim.Router = {
       match: function(name, View) {
         var options = {};
@@ -36,16 +44,26 @@
       }
     };
 
+    for (var i = 0; i < routerElements.length; i++) {
+      var elementName = routerElements[i];
+      Exim.Router[elementName] = React.createElement.bind(React.createElement, ReactRouter[elementName]);
+    }
 
-    ['Link', 'transitionTo', 'goBack', 'replaceWith', 'Route', 'RouteHandler', 'State', 'Link'].forEach(function(name) {
-      Exim.Router[name] = ReactRouter[name]
-    });
+    for (var i = 0; i < copyItems.length; i++) {
+      var itemName = copyItems[i];
+      Exim.Router[itemName] = ReactRouter[itemName];
+    }
   }
+
+  Exim.createView = function (classArgs) {
+    var ReactClass = React.createClass(classArgs);
+    var ReactElement = React.createElement.bind(React.createElement, ReactClass);
+    return ReactElement;
+  };
 
   Exim.createAction = Reflux.createAction;
   Exim.createActions = Reflux.createActions;
   Exim.createStore = Reflux.createStore;
-  Exim.createView = React.createClass;
 
   return Exim;
 });

--- a/src/header.js
+++ b/src/header.js
@@ -13,7 +13,18 @@
   }
 })(this, function(root, Reflux) {
   "use strict";
-  var React = require('react');
-  var ReactRouter = require('react-router');
-
+  var React, ReactRouter;
   var Reflux = {};
+
+  if (typeof define === 'function' && define.amd) {
+    React = require('react');
+    ReactRouter = require('react-router');
+  }
+  else if (typeof module === 'object' && module.exports){
+    React = module.exports.React;
+    ReactRouter = module.exports.ReactRouter;
+  }
+  else {
+    React = window.React;
+    ReactRouter = window.ReactRouter;
+  }

--- a/src/header.js
+++ b/src/header.js
@@ -16,6 +16,4 @@
   var React = require('react');
   var ReactRouter = require('react-router');
 
-  if (typeof React === 'undefined') {
-    throw("React required");
-  }
+  var Reflux = {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,22 +24,30 @@ if (typeof define === 'function' && define.amd) {
   utils.EventEmitter = require('EventEmitter')
 }
 else if (typeof module === 'object' && module.exports){
-    utils.EventEmitter = module.exports.EventEmitter;
+  utils.EventEmitter = module.exports.EventEmitter;
 }
 else {
-    utils.EventEmitter = window.EventEmitter;
+  utils.EventEmitter = window.EventEmitter;
 }
 
 utils.isFunction = function(value) {
-    return typeof value === 'function';
+  return typeof value === 'function';
 };
 
 utils.nextTick = function(callback) {
-    setTimeout(callback, 0);
+  setTimeout(callback, 0);
 };
 
 utils.capitalize = function(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+utils.inheritMixins = function (target, mixins) {
+  if (mixins) {
+    mixins.forEach(function (mixin) {
+      utils.extend(target.prototype, mixin);
+    })
+  }
 };
 
 utils.lookupCallback = function(store, name, prefix) {
@@ -57,11 +65,11 @@ utils.lookupCallback = function(store, name, prefix) {
 };
 
 utils.object = function(keys,vals){
-    var o={}, i=0;
-    for(;i<keys.length;i++){
-        o[keys[i]] = vals[i];
-    }
-    return o;
+  var o={}, i=0;
+  for(;i<keys.length;i++){
+      o[keys[i]] = vals[i];
+  }
+  return o;
 };
 
 utils.clone = function (orig) {


### PR DESCRIPTION
Add **createView**:
After React 0.13 update, we need to insert `React.createElement(SomeReactClass, someProps)` instead of just `SomeReactClass(someProps)`. 
Now, use `React.createView` to simply call your classes inside components.
Also, `SomeView().type` can be used as react-router handler.

*app.coffee:*
```coffeescript
{div} = Exim.DOM
{RouteHanlder} = Exim.Router

App = Exim.createView
  render: ->
    div className: 'app',
       name = @context.router.getCurrentPath()
       View({name})

View = Exim.createView
  render: ->
    div className: 'view',
      RouteHandler({key: @props.name})
```

*routes.coffee:*
```coffeescript
{Route} = Exim.Router 
Route name: 'app', path: '/', handler: App().type,
  Route name: 'some-view', handler: someView
```
