### PR TITLE
fix for react-hot-loader 'removing listener'

### DIFF
--- a/src/mixins/connect.js
+++ b/src/mixins/connect.js
@@ -18,7 +18,8 @@ export default function getConnectMixin (store) {
     },
 
     componentWillUnmount: function () {
-      listener.off('update');
+      if (listener)
+        listener.off('update');
     }
   };
 }


### PR DESCRIPTION
Hi - another quick fix - found that listener became undefined when using react-hot-loader with Exim.