### PR TITLE
Call initial 'while' separate from 'on' transaction

### DIFF
--- a/exim.js
+++ b/exim.js
@@ -912,12 +912,12 @@ var Store = (function () {
           });
         }
 
+        if (while_) {
+          while_.call(state, true);
+        }
         // Actual execution.
         promise = promise.then(function (willResult) {
           return transaction("on", function () {
-            if (while_) {
-              while_.call(preserver, true);
-            }
             if (willResult == null) {
               return on_.apply(preserver, args);
             } else {

--- a/src/Store.js
+++ b/src/Store.js
@@ -284,11 +284,11 @@ export default class Store {
       }));
     }
 
+    if (while_) {
+      while_.call(state, true);
+    }
     // Actual execution.
     promise = promise.then(willResult => transaction('on', () => {
-      if (while_) {
-        while_.call(preserver, true);
-      }
       if (willResult == null) {
         return on_.apply(preserver, args);
       } else {


### PR DESCRIPTION
Calling it as part of the `on` transaction has some unnecessary consequences. Namely, if the `on` method returns a promise, `while`'s `set`s won't be actually set until the promise is resolved.

Given that, at least we, are using the `while` hook to store the status of action (`dataLoading: true`), delaying it until the promise is resolved essentially means that `dataLoading` will be **false** while it is actually loading.