### PR TITLE
Fix check for undefined

### DIFF
--- a/src/GlobalStore.js
+++ b/src/GlobalStore.js
@@ -16,7 +16,7 @@ export default class GlobalStore {
       if (values[bit]) {
         values = values[bit];
       } else {
-        values[bit] = (typeof init !== undefined && bits.length - 1 === i) ? init : {};
+        values[bit] = (init !== undefined && bits.length - 1 === i) ? init : {};
         values = values[bit];
       }
     });


### PR DESCRIPTION
`typeof` returns `string`, so `typeof init` will never `=== undefined`.