### PR TITLE
Fix updateState on array change; add tests for connect mixin

### DIFF
--- a/src/mixins/connect.js
+++ b/src/mixins/connect.js
@@ -28,7 +28,7 @@ const getConnectMixin = function(store, ...key) {
   const changeCallback = function() {
     const prev = this.state;
     const curr = getState();
-    const diff = Object.keys(curr).some(key => prev[key] !== curr[key]);
+    const diff = Object.keys(curr).some(key => Array.isArray(curr[key]) || (prev[key] !== curr[key]));
     if (diff) this.setState(curr);
   };
 

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+chai.should();
+
+import Store from '../src/Store';
+
+describe('Connect', () => {
+  describe('#get', () =>  {
+    it('tracks arrays changes', () => {
+      const onHandler = sinon.spy();
+      let changerCalled = false;
+      let data;
+
+      const config = {
+         initial: { data: [] },
+         actions: ['action'],
+         action: {
+            did: function(){ this.set('data', data); },
+            on: onHandler
+         }
+      };
+      const store = new Store(config);
+
+      let component = store.connect('data');
+      component.state = component.getInitialState();
+      component.setState = () => { changerCalled = true; };
+      component.componentWillMount();
+
+      data = store.get('data');
+      data.push('some-value');
+
+      return store.actions.action().then(() => {
+        store.get('data').length.should.equals(1);
+        changerCalled.should.equals(true, 'setState should be called on array change');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hello there.

Next code isn't works: 

```js
// mystore.js
initial: {
  data: []
}, 

someActionMethod() {
   let data = this.get('data');
   data.push({ attr: 'test'}); // this.get('data').length > 0 already
   this.set('data', data); // view will be not updated because diff from mixins/connect.js is false
   // you need to pass only new array like
   // this.set('data', data.slice())
}
```

This solution isn't the best one, but anyway, right now `curr` which passed to `this.setState` contains all attributes connected to *component*.