### PR TITLE
Fix mixin change callback

### DIFF
--- a/exim.js
+++ b/exim.js
@@ -1110,12 +1110,16 @@ var getConnectMixin = function getConnectMixin(store) {
       return getState();
     },
 
+    _changeCallback: function _changeCallback() {
+      changeCallback.call(this);
+    },
+
     componentWillMount: function componentWillMount() {
-      store.onChange(changeCallback, this);
+      store.onChange(this._changeCallback);
     },
 
     componentWillUnmount: function componentWillUnmount() {
-      store.offChange(changeCallback);
+      store.offChange(this._changeCallback);
     }
   };
 };

--- a/src/mixins/connect.js
+++ b/src/mixins/connect.js
@@ -37,12 +37,16 @@ const getConnectMixin = function(store, ...key) {
       return getState();
     },
 
+    _changeCallback: function() {
+      changeCallback.call(this);
+    },
+
     componentWillMount: function() {
-      store.onChange(changeCallback, this);
+      store.onChange(this._changeCallback);
     },
 
     componentWillUnmount: function() {
-      store.offChange(changeCallback);
+      store.offChange(this._changeCallback);
     }
   };
 };


### PR DESCRIPTION
There is an issue with 0.9.9, when you subscribe to state updates via mixin in an array of components, only the first component's state is being updated. Please check [this repo](https://github.com/stelmakh/debug-exim) to reproduce the issue.