### PR TITLE
Fix multiple mixins conflict issue

### DIFF
--- a/exim.js
+++ b/exim.js
@@ -1026,7 +1026,7 @@ module.exports = Store;
 "use strict";
 
 module.exports = {
-  allowedGetterProps: ["get", "initial", "actions"]
+  allowedGetterProps: ["get", "initial", "actions", "path"]
 };
 
 },{}],9:[function(require,module,exports){
@@ -1110,16 +1110,13 @@ var getConnectMixin = function getConnectMixin(store) {
       return getState();
     },
 
-    _changeCallback: function _changeCallback() {
-      changeCallback.call(this);
-    },
-
     componentWillMount: function componentWillMount() {
-      store.onChange(this._changeCallback);
+      this["" + store.path + "ChangeCallback"] = changeCallback.bind(this);
+      store.onChange(this["" + store.path + "ChangeCallback"]);
     },
 
     componentWillUnmount: function componentWillUnmount() {
-      store.offChange(this._changeCallback);
+      store.offChange(this["" + store.path + "ChangeCallback"]);
     }
   };
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,3 @@
 export default {
-  allowedGetterProps: ['get', 'initial', 'actions']
+  allowedGetterProps: ['get', 'initial', 'actions', 'path']
 };

--- a/src/mixins/connect.js
+++ b/src/mixins/connect.js
@@ -37,16 +37,13 @@ const getConnectMixin = function(store, ...key) {
       return getState();
     },
 
-    _changeCallback: function() {
-      changeCallback.call(this);
-    },
-
     componentWillMount: function() {
-      store.onChange(this._changeCallback);
+      this[`${store.path}ChangeCallback`] = changeCallback.bind(this);
+      store.onChange(this[`${store.path}ChangeCallback`]);
     },
 
     componentWillUnmount: function() {
-      store.offChange(this._changeCallback);
+      store.offChange(this[`${store.path}ChangeCallback`]);
     }
   };
 };


### PR DESCRIPTION
This one fixes the issue introduced in the #71. Though state update has been fixed, i've later noticed that the _changeCallback property causes conflicts when more than one connect mixin is used simultaneously. This PR modifies connect mixin to use different property names for different stores. Tested on a big project, works just fine.